### PR TITLE
fixed CSS inclusion if using shortcode with arguments

### DIFF
--- a/event-list.php
+++ b/event-list.php
@@ -77,6 +77,7 @@ class Event_List {
 			require_once( EL_PATH.'includes/sc_event-list.php' );
 			$this->shortcode = SC_Event_List::get_instance();
 		}
+        $this->enqueue_styles();
 		return $this->shortcode->show_html( $atts );
 	}
 
@@ -88,11 +89,15 @@ class Event_List {
 
 	public function print_styles() {
 		global $post;
-		if(is_active_widget(null, null, 'event_list_widget') || strstr($post->post_content, '[event-list]')) {
-			wp_register_style('event-list', EL_URL.'includes/css/event-list.css');
-			wp_enqueue_style( 'event-list');
+		if(is_active_widget(null, null, 'event_list_widget')) {
+            $this->enqueue_styles();
 		}
 	}
+
+    private function enqueue_styles() {
+        wp_register_style('event-list', EL_URL.'includes/css/event-list.css');
+        wp_enqueue_style( 'event-list');
+    }
 } // end class linkview
 
 


### PR DESCRIPTION
Hi,

I am using the the `[event-list]` shortcode in my posts and I noticed two little bugs in the current version of your plugin: 
1. The CSS is not properly loaded if you use the shortcode with some arguments. (e.g., `[event-list show_filterbar=true link_to_event=false]` )
   I fixed this by altering your if-guard in `Event_List::print_styles` from `strstr($post->post_content, '[event-list]')` to `strstr($post->post_content, '[event-list')`.
2. If I use the shortcode in my theme's template via `do_shortcode( '[event-list show_filterbar=true link_to_event=false]' );`, point 1 above is not triggered in either case, because the shortcode is not in the post's content.
   For me , enqueuing  the CSS style in `Event_List::shortcode_event_list` fixed the problem.

Actually, my solution for point 2 solves also point 1, so I combined the solutions, as you can see in the diff.

Keep up the good work!
