### PR TITLE
Loads any user translation first

### DIFF
--- a/event-list.php
+++ b/event-list.php
@@ -76,7 +76,12 @@ class Event_List {
 	} // end constructor
 
 	public function load_textdomain() {
-		load_plugin_textdomain('event-list', false, basename(EL_PATH).'/languages');
+		$domain = 'event-list';
+		// The "plugin_locale" filter is also used in load_plugin_textdomain()
+		$locale = apply_filters('plugin_locale', get_locale(), $domain);
+
+		load_textdomain($domain, WP_LANG_DIR.'/plugins/'.$domain.'-'.$locale.'.mo');
+		load_plugin_textdomain($domain, false, basename(EL_PATH).'/languages');		
 	}
 
 	public function shortcode_event_list($atts) {


### PR DESCRIPTION
As per recommended way to load plugin translations here: http://geertdedeckere.be/article/loading-wordpress-language-files-the-right-way

Otherwise with the current version, the fr_FR mo file that does not contain any useful translation strings will be used instead of any user defined translation file (e.g. languages/plugins/event-list-fr_FR).
