### PR TITLE
adds an excerpt option

### DIFF
--- a/includes/event.php
+++ b/includes/event.php
@@ -19,6 +19,7 @@ class EL_Event {
 	public $enddate = '0000-00-00';
 	public $starttime = '';
 	public $location = '';
+	public $excerpt = '';
 	public $content = '';
 
 	public function __construct($post) {
@@ -37,6 +38,7 @@ class EL_Event {
 
 	private function load_eventdata() {
 		$this->title = $this->post->post_title;
+		$this->excerpt = $this->post->post_excerpt;
 		$this->content = $this->post->post_content;
 		$postmeta = get_post_meta($this->post->ID);
 		foreach(array('startdate', 'enddate', 'starttime', 'location') as $meta) {
@@ -54,6 +56,7 @@ class EL_Event {
 		$postdata['post_type'] = 'el_events';
 		$postdata['post_status'] = 'publish';
 		$postdata['post_title'] = $eventdata['title'];
+		$postdata['post_excerpt'] = $eventdata['excerpt'];
 		$postdata['post_content'] = $eventdata['content'];
 		if(isset($eventdata['slug'])) {
 			$postdata['post_name'] = $eventdata['slug'];
@@ -272,10 +275,10 @@ class EL_Event {
 			// Print ellipsis ("...") if the html was truncated
 			if($truncated) {
 				if($link) {
-					$out .= ' <a href="'.$link.'">&hellip;</a>';
+					$out .= ' <a href="'.$link.'"> [read more...]</a>';
 				}
 				else {
-					$out .= ' &hellip;';
+					$out .= ' [read more...]';
 				}
 			}
 			// Close any open tags.

--- a/includes/events_post_type.php
+++ b/includes/events_post_type.php
@@ -93,7 +93,7 @@ class EL_Events_Post_Type {
 			'menu_position' => 23,
 			'menu_icon' => 'dashicons-calendar-alt',
 			'capability_type' => 'post',
-			'supports'=> array('title', 'editor', 'revisions', 'autor', 'thumbnail'),
+			'supports'=> array('title', 'editor', 'revisions', 'author', 'thumbnail', 'excerpt',),
 			'register_meta_box_cb' => null,
 			'taxonomies' => $this->use_post_categories ? array($this->post_cat_taxonomy) : array(),
 			'has_archive' => true,

--- a/includes/sc_event-list_helptexts.php
+++ b/includes/sc_event-list_helptexts.php
@@ -96,6 +96,11 @@ $sc_eventlist_helptexts = array(
 	                                            Choose "false" to always hide and "true" to always show the category.<br />
 	                                            With "event_list_only" the categories are only visible in the event list and with "single_event_only" only for a single event','event-list')),
 
+	'show_excerpt'     => array('val'    => array('false', 'true', 'event_list_only', 'single_event_only'),
+	                            'desc'   => __('This attribute specifies if the excerpt is displayed in the event list.<br />
+	                                            Choose "false" to always hide and "true" to always show the excerpt.<br />
+	                                            With "event_list_only" the excerpt is only visible in the event list and with "single_event_only" only for a single event','event-list')),
+
 	'show_content'     => array('val'    => array('false', 'true', 'event_list_only', 'single_event_only'),
 	                            'desc'   => __('This attribute specifies if the content is displayed in the event list.<br />
 	                                            Choose "false" to always hide and "true" to always show the content.<br />

--- a/includes/widget.php
+++ b/includes/widget.php
@@ -29,6 +29,7 @@ class EL_Widget extends WP_Widget {
 			'show_starttime'       => array('std_value' => 'true'),
 			'show_location'        => array('std_value' => 'false'),
 			'location_length'      => array('std_value' => '0'),
+			'show_excerpt'         => array('std_value' => 'false'),
 			'show_content'         => array('std_value' => 'false'),
 			'content_length'       => array('std_value' => '0'),
 			'url_to_page'          => array('std_value' => ''),
@@ -75,6 +76,7 @@ class EL_Widget extends WP_Widget {
 		$shortcode .= ' show_starttime='.$instance['show_starttime'];
 		$shortcode .= ' show_location='.$instance['show_location'];
 		$shortcode .= ' location_length='.$instance['location_length'];
+		$shortcode .= ' show_excerpt='.$instance['show_excerpt'];
 		$shortcode .= ' show_content='.$instance['show_content'];
 		$shortcode .= ' content_length='.$instance['content_length'];
 		if($linked_page_is_set && $linked_page_id_is_set) {

--- a/includes/widget_helptexts.php
+++ b/includes/widget_helptexts.php
@@ -55,6 +55,13 @@ $widget_items_helptexts = array(
 	                                'form_style'    => 'margin:0 0 0.6em 0.9em',
 	                                'form_width'    => 40),
 
+	'show_excerpt' =>         array('type'          => 'checkbox',
+	                                'caption'       => __('Show event excerpt','event-list'),
+	                                'caption_after' => null,
+	                                'tooltip'       => __('This option defines if the event excerpt will be displayed.','event-list'),
+	                                'form_style'    => 'margin:0 0 0.2em 0',
+	                                'form_width'    => null),
+
 	'show_content' =>         array('type'          => 'checkbox',
 	                                'caption'       => __('Show event content','event-list'),
 	                                'caption_after' => null,


### PR DESCRIPTION
This adds an excerpt option to the addon.  This can be used in shortcode displays and the widget.

The excerpt is first generated from the custom excerpt field in the post.  If that is not there, it then checks the content for a read more tag and uses the content before the tag.  Finally if that is not there, it will use the main content and if you have entered a content_length number, it will truncate to that length.